### PR TITLE
Use Pin Box for Unpin Future

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,7 @@
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
-
 #![feature(async_await)]
-#![feature(async_closure)]
 
 pub use client::{Error, HttpsConnecting, HttpsConnector};
 pub use stream::{MaybeHttpsStream, TlsStream};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,8 +3,8 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-pub use tokio_tls::TlsStream;
 use tokio_io::{AsyncRead, AsyncWrite};
+pub use tokio_tls::TlsStream;
 
 /// A stream that might be protected with TLS.
 pub enum MaybeHttpsStream<T> {


### PR DESCRIPTION
* Use Pin Box for Unpin Future
* Replace async closure with async block as async closures are not part of first cut of async-await
* Cargo fmt